### PR TITLE
Add support for fileDimensions export argument

### DIFF
--- a/geeutils/eu.py
+++ b/geeutils/eu.py
@@ -133,7 +133,7 @@ def export_to_gcs(aoi: dict,
         gcs_bucket_name: The name of the target GCS bucket.
         gcs_path: The path in the bucket where the image should be exported.
         crs: Optional.  If provided, convert the image to this Coordinate Reference System.
-        file_dimensions: Optional.  If provided, exported images will have the specified height and width in pixels.  Must be a multiple of 256.
+        file_dimensions: Optional.  If provided, exported images will have the specified height and width in pixels.  Must be a positive integer multiple of 256.
         skip_empty_tiles: Optional.  If True, empty tiles will not be exported (default False).
 
     Returns:
@@ -154,7 +154,13 @@ def export_to_gcs(aoi: dict,
     }
     if crs:
         export_kwargs.update({'crs': crs})
-    if file_dimensions:
+    if file_dimensions is not None:
+        try:
+            file_dimensions = int(file_dimensions)
+            assert file_dimensions > 0
+            assert file_dimensions % 256 == 0
+        except (AssertionError, ValueError):
+            raise ValueError(f'file_dimensions value {file_dimensions} is not a positive integer multiple of 256')
         export_kwargs.update({'fileDimensions': [file_dimensions] * 2})
     export = ee.batch.Export.image.toCloudStorage(**export_kwargs)
     export.start()

--- a/geeutils/eu.py
+++ b/geeutils/eu.py
@@ -121,6 +121,7 @@ def export_to_gcs(aoi: dict,
                   gcs_bucket_name: str,
                   gcs_path: str,
                   crs: str=None,
+                  file_dimensions: int=None,
                   skip_empty_tiles: bool=False) -> str:
     """Export an image to Google Cloud Storage (GCS).
 
@@ -132,6 +133,7 @@ def export_to_gcs(aoi: dict,
         gcs_bucket_name: The name of the target GCS bucket.
         gcs_path: The path in the bucket where the image should be exported.
         crs: Optional.  If provided, convert the image to this Coordinate Reference System.
+        file_dimensions: Optional.  If provided, exported images will have the specified height and width in pixels.  Must be a multiple of 256.
         skip_empty_tiles: Optional.  If True, empty tiles will not be exported (default False).
 
     Returns:
@@ -152,6 +154,8 @@ def export_to_gcs(aoi: dict,
     }
     if crs:
         export_kwargs.update({'crs': crs})
+    if file_dimensions:
+        export_kwargs.update({'fileDimensions': [file_dimensions] * 2})
     export = ee.batch.Export.image.toCloudStorage(**export_kwargs)
     export.start()
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md", "r") as f:
 
 setup(
     name='geeutils',
-    version='0.4.0',
+    version='0.5.0',
     description='Utility functions for Google Earth Engine',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_eu.py
+++ b/tests/test_eu.py
@@ -186,6 +186,7 @@ def test_export_to_gcs(input_crs, extra_kwarg):
     fake_gcs_bucket_name = 'bogus-bucket'
     fake_gcs_path= 'bogus/path/to/blob'
     mock_geometry = MagicMock()
+    fake_file_dimensions = 256
     fake_task_id = 'MYFAKETASKIDMYFAKETASKID'
     mock_ee = MagicMock()
     mock_export = MagicMock(id=fake_task_id)
@@ -197,7 +198,8 @@ def test_export_to_gcs(input_crs, extra_kwarg):
                                           fake_image,
                                           fake_gcs_bucket_name,
                                           fake_gcs_path,
-                                          input_crs)
+                                          input_crs,
+                                          fake_file_dimensions)
 
     expected_export_kwargs = {
         'image': fake_image,
@@ -206,6 +208,7 @@ def test_export_to_gcs(input_crs, extra_kwarg):
         'region': mock_geometry,
         'scale': 10,
         'maxPixels': 1e13,
+        'fileDimensions': [fake_file_dimensions] * 2,
         'skipEmptyTiles': False
     }
     expected_export_kwargs.update(extra_kwarg)

--- a/tests/test_eu.py
+++ b/tests/test_eu.py
@@ -176,44 +176,68 @@ def test_export_to_asset(input_crs, extra_kwarg):
     assert actual_task_id == fake_task_id
 
 
-@pytest.mark.parametrize('input_crs,extra_kwarg', [
-    (None, {}),
-    ('EPSG:BOGUS', {'crs': 'EPSG:BOGUS'})
-])
-def test_export_to_gcs(input_crs, extra_kwarg):
-    fake_aoi = {'foo': 'bar'}
-    fake_image = MagicMock()
-    fake_gcs_bucket_name = 'bogus-bucket'
-    fake_gcs_path= 'bogus/path/to/blob'
-    mock_geometry = MagicMock()
-    fake_file_dimensions = 256
-    fake_task_id = 'MYFAKETASKIDMYFAKETASKID'
-    mock_ee = MagicMock()
-    mock_export = MagicMock(id=fake_task_id)
-    mock_ee.Geometry.Polygon.return_value = mock_geometry
-    mock_ee.batch.Export.image.toCloudStorage.return_value = mock_export
+class TestExportToGcs:
 
-    with patch('geeutils.eu.ee', mock_ee):
-        actual_task_id = eu.export_to_gcs(fake_aoi,
-                                          fake_image,
-                                          fake_gcs_bucket_name,
-                                          fake_gcs_path,
-                                          input_crs,
-                                          fake_file_dimensions)
+    @pytest.mark.parametrize('input_crs,extra_kwarg', [
+        (None, {}),
+        ('EPSG:BOGUS', {'crs': 'EPSG:BOGUS'})
+    ])
+    def test_happy_path(self, input_crs, extra_kwarg):
+        fake_aoi = {'foo': 'bar'}
+        fake_image = MagicMock()
+        fake_gcs_bucket_name = 'bogus-bucket'
+        fake_gcs_path= 'bogus/path/to/blob'
+        mock_geometry = MagicMock()
+        fake_file_dimensions = 256
+        fake_task_id = 'MYFAKETASKIDMYFAKETASKID'
+        mock_ee = MagicMock()
+        mock_export = MagicMock(id=fake_task_id)
+        mock_ee.Geometry.Polygon.return_value = mock_geometry
+        mock_ee.batch.Export.image.toCloudStorage.return_value = mock_export
 
-    expected_export_kwargs = {
-        'image': fake_image,
-        'bucket': fake_gcs_bucket_name,
-        'fileNamePrefix': fake_gcs_path,
-        'region': mock_geometry,
-        'scale': 10,
-        'maxPixels': 1e13,
-        'fileDimensions': [fake_file_dimensions] * 2,
-        'skipEmptyTiles': False
-    }
-    expected_export_kwargs.update(extra_kwarg)
+        with patch('geeutils.eu.ee', mock_ee):
+            actual_task_id = eu.export_to_gcs(fake_aoi,
+                                              fake_image,
+                                              fake_gcs_bucket_name,
+                                              fake_gcs_path,
+                                              crs=input_crs,
+                                              file_dimensions=fake_file_dimensions)
 
-    mock_ee.Geometry.Polygon.assert_called_once_with(fake_aoi)
-    mock_ee.batch.Export.image.toCloudStorage.assert_called_once_with(**expected_export_kwargs)
-    mock_export.start.assert_called_once_with()
-    assert actual_task_id == fake_task_id
+        expected_export_kwargs = {
+            'image': fake_image,
+            'bucket': fake_gcs_bucket_name,
+            'fileNamePrefix': fake_gcs_path,
+            'region': mock_geometry,
+            'scale': 10,
+            'maxPixels': 1e13,
+            'fileDimensions': [fake_file_dimensions] * 2,
+            'skipEmptyTiles': False
+        }
+        expected_export_kwargs.update(extra_kwarg)
+
+        mock_ee.Geometry.Polygon.assert_called_once_with(fake_aoi)
+        mock_ee.batch.Export.image.toCloudStorage.assert_called_once_with(**expected_export_kwargs)
+        mock_export.start.assert_called_once_with()
+        assert actual_task_id == fake_task_id
+
+    @pytest.mark.parametrize('input_file_dimensions', [
+        -256,
+        0,
+        1000,
+        'not a numeric type'
+    ])
+    def test_raises_if_file_dimensions_not_valid(self, input_file_dimensions):
+        fake_aoi = {'foo': 'bar'}
+        fake_image = MagicMock()
+        fake_gcs_bucket_name = 'bogus-bucket'
+        fake_gcs_path= 'bogus/path/to/blob'
+        fake_file_dimensions = input_file_dimensions
+        mock_ee = MagicMock()
+
+        with pytest.raises(ValueError):
+            with patch('geeutils.eu.ee', mock_ee):
+                actual_task_id = eu.export_to_gcs(fake_aoi,
+                                                  fake_image,
+                                                  fake_gcs_bucket_name,
+                                                  fake_gcs_path,
+                                                  file_dimensions=fake_file_dimensions)


### PR DESCRIPTION
Supports https://asudev.jira.com/browse/ACA-729

This PR gives anyone exporting imagery from GCS the option to specify the size (dimensions) of the exported rasters.  In the context of this bug, it lets us export turbidity raster in more granular images so we can create a more precise boundary around the areas with data.